### PR TITLE
Update links to glTF spec

### DIFF
--- a/complex_import/manual.md
+++ b/complex_import/manual.md
@@ -21,7 +21,7 @@ the transfer of larger scenes, but has a few caveats we will investigate in this
 
 In order to implement a robust asset pipeline based on glTF and the Ramses Composer, it is important to understand how glTF works first. Read this section carefully!
 
-According to the [glTF 2.0 specification](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0) all objects in a glTF asset file are stored as JSON arrays.
+According to the [glTF 2.0 specification](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html) all objects in a glTF asset file are stored as JSON arrays.
 They are uniquely identified by their index in the array (0, 1, ... N), _not_ by their name. This rule applies
 to nodes, meshes, and all other kinds of array-based objects. This way of ordering is very efficient and
 robust, but it does not allow tracking of objects across different versions of the same file when objects'

--- a/conventions/manual.md
+++ b/conventions/manual.md
@@ -45,7 +45,7 @@ The rendering order corresponds to the order in which MeshNodes appear in the Sc
 
 ## Attributes
 
-The Ramses Composer's primary import format is GLTF 2.0. It is quite flexible and allows transmission of mesh attributes in a portable way ([see specification](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#meshes)) which can be used in custom GLSL shaders. In order to use them, you have to create attributes with a specific name. The following table shows the mapping between mesh attributes provided by GLTF and the names and types the Composer expects for them:
+The Ramses Composer's primary import format is GLTF 2.0. It is quite flexible and allows transmission of mesh attributes in a portable way ([see specification](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-mesh)) which can be used in custom GLSL shaders. In order to use them, you have to create attributes with a specific name. The following table shows the mapping between mesh attributes provided by GLTF and the names and types the Composer expects for them:
 
 
 |GLTF Name   |Accessor Type(s)    |Description|Attribute name in custom GLSL shaders|

--- a/hello_world/manual.md
+++ b/hello_world/manual.md
@@ -27,7 +27,7 @@ The scene graph of the cube consists of a node (with a child MeshNode) and a cam
 The scene graph view shows all elements in the scene. In the left column, you can inspect the names and structure of the nodes/meshes/cameras etc, while in the 'Type' column you can see
 the type of the object. Nodes generally keep only positional data, MeshNodes carry mesh information and settings. MeshNodes correspond to draw calls in OpenGL terminology.
 
-The Camera is a special object which affects the entire SceneGraph by defining the view space of it. The standard camera in the Ramses Composer is facing towards the negative Z axis, and has the positive Y axis as "UP". This corresponds to OpenGL "defaults" from earlier times before programmable shaders, and also to the default GLTF 2.0 convention.
+The Camera is a special object which affects the entire SceneGraph by defining the view space of it. The standard camera in the Ramses Composer is facing towards the negative Z axis, and has the positive Y axis as "UP". This corresponds to OpenGL "defaults" from earlier times before programmable shaders, and also to the default glTF 2.0 convention.
 
 You can click and inspect each element's properties in the Property panel. You will notice that the Root node has rotation values
 which affect the position of the child Cube when changed. You can also notice that the MeshNode has links to Resources in its property view:
@@ -41,16 +41,16 @@ Which leads us to the next data view: [the resources](#resources).
 ## Resources
 
 Resources are data objects which can be reused throughout the scene graph. Think of them as immutable objects which are composed out of external data. For example,
-a Mesh resource represents a named mesh which is imported from a GLTF 2.0 file:
+a Mesh resource represents a named mesh which is imported from a glTF 2.0 file:
 
 ![](./docs/mesh_resource.png)
 
-See the [section further down](#export-gltf-from-blender) for details how to create/export GLTF 2.0 files.
+See the [section further down](#export-gltf-from-blender) for details how to create/export glTF 2.0 files.
 
-**Note**: if you are new to the GLTF 2.0 format, have a look [at the docs](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0).
+**Note**: if you are new to the glTF 2.0 format, have a look [at the docs](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html).
 
-You can modify the path of the mesh to a different GLTF file, and the mesh will update itself.
-It also monitors the GLTF file it currently refers to for changes, and "hot-reloads" itself when the file is changed.
+You can modify the path of the mesh to a different glTF file, and the mesh will update itself.
+It also monitors the glTF file it currently refers to for changes, and "hot-reloads" itself when the file is changed.
 
 Another type of resource is the Material. A Material points to GLSL files which hold the source code for its shaders. Changing the URI of the shader files, or the files themselves, will
 immediately update the state of the Material resource, and all MeshNodes which refer to it. Try and modify the color in [the fragment shader file](./shaders/simple.frag) and observe the results. If you are familiar with shaders, but new to GLSL, you can find the quick reference of the OpenGL ES 3.0 flavor [here](https://www.khronos.org/files/opengles3-quick-reference-card.pdf) - this is the base version of GLSL typically used by modern consumer electronics.
@@ -59,15 +59,15 @@ immediately update the state of the Material resource, and all MeshNodes which r
 
 You can save the project with your changes, or Save As a different file. Note that the Composer stores relative paths - so when saving to a different place on disk, the __new_cube.rca__ file will re-calculate the relative file paths to its external resources. This will notably not work with network drives!
 
-## Export GLTF from Blender
+## Export glTF from Blender
 
 The Composer is not a designer tool - it can't be used to create meshes or images, instead it only __composes__ them to a project ready to be used by an application. The cube in this example is a 3D mesh, despite being a simple one. You can create it very easily with Blender - it has the cube as its default scene.
 
-You can export a GLTF 2.0 file from Blender over the File->Export->GLTF 2.0 menu:
+You can export a glTF 2.0 file from Blender over the File->Export->glTF 2.0 menu:
 
 ![](./docs/export_gltf.png)
 
-You can leave the settings unchanged, but we highly recommend using the text form of GLTF 2.0, as the Blender tooltip conveniently mentions:
+You can leave the settings unchanged, but we highly recommend using the text form of glTF 2.0, as the Blender tooltip conveniently mentions:
 
 ![](./docs/export_settings.png)
 
@@ -79,7 +79,7 @@ and all animation properties.
 
 To recreate the sample cube project from scratch, follow these steps:
 
-* Export the default cube from blender (as GLTF 2.0) as described in [the section above](#export-gltf-from-blender)
+* Export the default cube from blender (as glTF 2.0) as described in [the section above](#export-gltf-from-blender)
 * Create a new project in Ramses Composer
 * Delete the default cube in Ramses Composer (in the Scene Graph view)
     * Select the default Node and press 'delete'
@@ -89,7 +89,7 @@ To recreate the sample cube project from scratch, follow these steps:
 * Create a new Mesh in the resources window
     * Right click -> Create Mesh
     * Give it a name (optionally)
-    * In the URI field (Property Browser) select the path to the GLTF file exported by Blender
+    * In the URI field (Property Browser) select the path to the glTF file exported by Blender
     * Click the MeshNode in the scene graph and point it to the newly added Mesh resource (select mesh via drop down in property browser)
 * Create a new Material in the resources window
     * Right click -> Create Material


### PR DESCRIPTION
Seems like the upstream links changed. Update the docs accordingly.