### PR TITLE
move time_ms from the monkey example and update with new features

### DIFF
--- a/monkey/docs/link_icon.png
+++ b/monkey/docs/link_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a328962c0a6be6dd993d08f182d3892717c0a24febf6e96afee03ba354140cc9
+size 521

--- a/monkey/docs/lua_script.png
+++ b/monkey/docs/lua_script.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e81b0c45625789c4e7bd0644cfcef808691cc369bb468e7a0cf3edcbf1966e2a
-size 18379
+oid sha256:f25a7518b50ba58b6d2fc246bcd2642744b03aafc412b424ed8f7cbd6958f0fe
+size 23996

--- a/monkey/docs/search_properties.png
+++ b/monkey/docs/search_properties.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48dfcc61f7053d90aaeb300347259c470dee5c0f4eec7fee56aa9e3a5ecc84ac
-size 3938
+oid sha256:e762fe5b8a23dca87d5b9e0b97b506629759947e6b1818b975d72f6af724bb18
+size 4563

--- a/monkey/manual.md
+++ b/monkey/manual.md
@@ -91,17 +91,44 @@ Don't worry - if you know any other scripting language, Lua is really easy to le
 Back to our example, the LightControl Lua script maps a set of static lights to a set of fixed directions,
 and emulates disco-like light colors. Let's have a look how it does that.
 
-Opening the script file, you will find two functions - an `interface()` and a `run()` function.
-Ramses Composer expects to find these two functions in every Lua script.
-The `interface()` method declares the expected inputs and the produced outputs of the script (note the IN and OUT global variables).
-Those are the same you will see in the Property Browser under the `Inputs` and `Outputs` tabs respectively.
+Opening the script file, you will find three functions - an `interface()`, an init() and a `run()` function. Let's
+have a look at each of them.
+
+### The interface() function
+
+Ramses Composer expects to find an `interface()` function in every Lua script.
+The `interface()` declares the expected inputs and the produced outputs of the script by
+adding entries in the IN and OUT global variables and specifying their type (integer, floating point number, string, etc.).
+Those properties are the same you will see in the Property Browser under the `Inputs` and `Outputs` tabs respectively.
+Each property receives a default value - 0, 0.0, empty string, etc.. Inputs can be assigned other values in
+the composer, while outputs can only be modified by the Lua script itself and are thus "greyed out" in the editor.
+
+### The run() function
+
+The `run()` function is another mandatory component of every Lua script. It is executed whenever any
+of the inputs changed and the outputs need re-evaluating.
+
+In this example, the `run()` function sets the light direction based on the current light id and optionally the diffuse
+color of the monkeys. You can modify the input values and observe the output values changing according to the script logic.
+
+### The init() function
+
+Sometimes, it's useful to have global variables which are initialized once and always available. The optional `init()`
+function does just that - allows any data to be stored in the `GLOBAL` table and referred to either from the `interface()` or
+from the `run()` functions.
+
+In this example, we use the `GLOBAL` table to store a default diffuse color - one which is assigned to the corresponding
+diffuse color output if no input data is provided.
+
+## What does the Lua script do?
 
 You can modify the input values and observe the output values changing according to the script logic.
 For example, you can set `0`, `1` or `2` in the light_id field, and observe that the lighting of the monkeys changes. But why?
 
 First, the `run()` method of the Lua script is executed whenever any of the inputs changed and the outputs need re-evaluating. In this example, the `run()`
-method sets the light direction based on the current light id and the light color based on the simulated time.
-But which values to use? As documented above the script's `interface()` method, setting light_id to 0, 1 and 2 switches the light position to different static values.
+method sets the light direction based on the current light id.
+But which values to use? As documented above the script's `interface()` method, setting light_id to 0, 1 and 2
+switches the light position to different static values.
 This kind of documentation is supposed to help a software developer to integrate
 the asset in a real application - where these values would come from the application logic.
 
@@ -124,9 +151,6 @@ The link mechanism is designed to make it possible
 to control several things with a single script. If you want to have a different mapping between scripts and "linked objects", you can create multiple instances which use the same Lua file as source, or you can use [prefabs](../prefabs/manual.md).
 
 You can find more details and specifics on the Lua syntax and features [in a dedicated section](../lua_syntax/manual.md).
-
-**Note**: you may notice that the LuaScript has a second input called 'time_ms'. Try to figure out what it does
-and how it is supposed to be used by an application!
 
 ## Create Suzanne in Blender
 

--- a/monkey/manual.md
+++ b/monkey/manual.md
@@ -91,7 +91,7 @@ Don't worry - if you know any other scripting language, Lua is really easy to le
 Back to our example, the LightControl Lua script maps a set of static lights to a set of fixed directions,
 and emulates disco-like light colors. Let's have a look how it does that.
 
-Opening the script file, you will find three functions - an `interface()`, an init() and a `run()` function. Let's
+Opening the script file, you will find three functions - an `interface()`, an `init()` and a `run()` function. Let's
 have a look at each of them.
 
 ### The interface() function
@@ -100,7 +100,7 @@ Ramses Composer expects to find an `interface()` function in every Lua script.
 The `interface()` declares the expected inputs and the produced outputs of the script by
 adding entries in the IN and OUT global variables and specifying their type (integer, floating point number, string, etc.).
 Those properties are the same you will see in the Property Browser under the `Inputs` and `Outputs` tabs respectively.
-Each property receives a default value - 0, 0.0, empty string, etc.. Inputs can be assigned other values in
+Each property receives a default value - `0` (int), `0.0` (float), `""` (string), etc.. Inputs can be assigned other values in
 the composer, while outputs can only be modified by the Lua script itself and are thus "greyed out" in the editor.
 
 ### The run() function

--- a/monkey/manual.md
+++ b/monkey/manual.md
@@ -138,7 +138,7 @@ script's output property 'light_direction'? These values are
 dynamically obtained from the Lua script we just inspected.
 
 Any objects in the scene can be linked to the values produced by any LuaScript. You can add, remove and switch the
-source of such links over the `link` icon symbol. The popup window supports text-based search which filters all
+source of such links over the link icon (![](./docs/link_icon.png)). The popup window supports text-based search which filters all
 properties in the project by their name (and only lists properties with a compatible type!). Try modifying
 one of the link texts by deleting everything after "light_" and observe that
 now there are two options for the link - the light_direction and light_color.

--- a/monkey/monkey.rca
+++ b/monkey/monkey.rca
@@ -1,7 +1,7 @@
 {
     "externalProjects": {
     },
-    "fileVersion": 17,
+    "fileVersion": 21,
     "instances": [
         {
             "properties": {
@@ -374,6 +374,18 @@
         {
             "properties": {
                 "backgroundColor": {
+                    "w": {
+                        "annotations": [
+                            {
+                                "properties": {
+                                    "max": 1,
+                                    "min": 0
+                                },
+                                "typeName": "RangeAnnotationDouble"
+                            }
+                        ],
+                        "value": 1
+                    },
                     "x": {
                         "annotations": [
                             {
@@ -606,7 +618,7 @@
                                             "typeName": "RangeAnnotationDouble"
                                         }
                                     ],
-                                    "value": 0.279415488243103
+                                    "value": 0.2800000011920929
                                 },
                                 "y": {
                                     "annotations": [
@@ -618,7 +630,7 @@
                                             "typeName": "RangeAnnotationDouble"
                                         }
                                     ],
-                                    "value": 0.8253356218338013
+                                    "value": 0.8199999928474426
                                 },
                                 "z": {
                                     "annotations": [
@@ -630,7 +642,7 @@
                                             "typeName": "RangeAnnotationDouble"
                                         }
                                     ],
-                                    "value": 0.5646424889564514
+                                    "value": 0.6000000238418579
                                 }
                             },
                             "typeName": "Vec3f::EngineTypeAnnotation::LinkEndAnnotation"
@@ -1081,10 +1093,62 @@
             "properties": {
                 "luaInputs": {
                     "order": [
-                        "light_id",
-                        "time_ms"
+                        "diffuse_color",
+                        "light_id"
                     ],
                     "properties": {
+                        "diffuse_color": {
+                            "annotations": [
+                                {
+                                    "properties": {
+                                        "engineType": 8
+                                    },
+                                    "typeName": "EngineTypeAnnotation"
+                                },
+                                {
+                                    "typeName": "LinkEndAnnotation"
+                                }
+                            ],
+                            "properties": {
+                                "x": {
+                                    "annotations": [
+                                        {
+                                            "properties": {
+                                                "max": 1,
+                                                "min": 0
+                                            },
+                                            "typeName": "RangeAnnotationDouble"
+                                        }
+                                    ],
+                                    "value": 0
+                                },
+                                "y": {
+                                    "annotations": [
+                                        {
+                                            "properties": {
+                                                "max": 1,
+                                                "min": 0
+                                            },
+                                            "typeName": "RangeAnnotationDouble"
+                                        }
+                                    ],
+                                    "value": 0
+                                },
+                                "z": {
+                                    "annotations": [
+                                        {
+                                            "properties": {
+                                                "max": 1,
+                                                "min": 0
+                                            },
+                                            "typeName": "RangeAnnotationDouble"
+                                        }
+                                    ],
+                                    "value": 0
+                                }
+                            },
+                            "typeName": "Vec3f::EngineTypeAnnotation::LinkEndAnnotation"
+                        },
                         "light_id": {
                             "annotations": [
                                 {
@@ -1099,21 +1163,6 @@
                             ],
                             "typeName": "Int::EngineTypeAnnotation::LinkEndAnnotation",
                             "value": 0
-                        },
-                        "time_ms": {
-                            "annotations": [
-                                {
-                                    "properties": {
-                                        "engineType": 2
-                                    },
-                                    "typeName": "EngineTypeAnnotation"
-                                },
-                                {
-                                    "typeName": "LinkEndAnnotation"
-                                }
-                            ],
-                            "typeName": "Int::EngineTypeAnnotation::LinkEndAnnotation",
-                            "value": 6000
                         }
                     }
                 },
@@ -1146,7 +1195,7 @@
                                             "typeName": "RangeAnnotationDouble"
                                         }
                                     ],
-                                    "value": 0.279415488243103
+                                    "value": 0.2800000011920929
                                 },
                                 "y": {
                                     "annotations": [
@@ -1158,7 +1207,7 @@
                                             "typeName": "RangeAnnotationDouble"
                                         }
                                     ],
-                                    "value": 0.8253356218338013
+                                    "value": 0.8199999928474426
                                 },
                                 "z": {
                                     "annotations": [
@@ -1170,7 +1219,7 @@
                                             "typeName": "RangeAnnotationDouble"
                                         }
                                     ],
-                                    "value": 0.5646424889564514
+                                    "value": 0.6000000238418579
                                 }
                             },
                             "typeName": "Vec3f::EngineTypeAnnotation::LinkStartAnnotation"
@@ -2124,17 +2173,17 @@
     ],
     "logicEngineVersion": [
         0,
-        11,
+        13,
         0
     ],
     "racoVersion": [
         0,
-        9,
-        2
+        11,
+        0
     ],
     "ramsesVersion": [
         27,
         0,
-        113
+        114
     ]
 }

--- a/monkey/monkey.rca
+++ b/monkey/monkey.rca
@@ -1094,10 +1094,63 @@
                 "luaInputs": {
                     "order": [
                         "diffuse_color",
+                        "light_color",
                         "light_id"
                     ],
                     "properties": {
                         "diffuse_color": {
+                            "annotations": [
+                                {
+                                    "properties": {
+                                        "engineType": 8
+                                    },
+                                    "typeName": "EngineTypeAnnotation"
+                                },
+                                {
+                                    "typeName": "LinkEndAnnotation"
+                                }
+                            ],
+                            "properties": {
+                                "x": {
+                                    "annotations": [
+                                        {
+                                            "properties": {
+                                                "max": 1,
+                                                "min": 0
+                                            },
+                                            "typeName": "RangeAnnotationDouble"
+                                        }
+                                    ],
+                                    "value": 0
+                                },
+                                "y": {
+                                    "annotations": [
+                                        {
+                                            "properties": {
+                                                "max": 1,
+                                                "min": 0
+                                            },
+                                            "typeName": "RangeAnnotationDouble"
+                                        }
+                                    ],
+                                    "value": 0
+                                },
+                                "z": {
+                                    "annotations": [
+                                        {
+                                            "properties": {
+                                                "max": 1,
+                                                "min": 0
+                                            },
+                                            "typeName": "RangeAnnotationDouble"
+                                        }
+                                    ],
+                                    "value": 0
+                                }
+                            },
+                            "typeName": "Vec3f::EngineTypeAnnotation::LinkEndAnnotation"
+                        },
+                        "light_color": {
                             "annotations": [
                                 {
                                     "properties": {
@@ -1169,6 +1222,7 @@
                 "luaOutputs": {
                     "order": [
                         "diffuse_color",
+                        "light_color",
                         "light_direction"
                     ],
                     "properties": {
@@ -1220,6 +1274,58 @@
                                         }
                                     ],
                                     "value": 0.6000000238418579
+                                }
+                            },
+                            "typeName": "Vec3f::EngineTypeAnnotation::LinkStartAnnotation"
+                        },
+                        "light_color": {
+                            "annotations": [
+                                {
+                                    "properties": {
+                                        "engineType": 8
+                                    },
+                                    "typeName": "EngineTypeAnnotation"
+                                },
+                                {
+                                    "typeName": "LinkStartAnnotation"
+                                }
+                            ],
+                            "properties": {
+                                "x": {
+                                    "annotations": [
+                                        {
+                                            "properties": {
+                                                "max": 1,
+                                                "min": 0
+                                            },
+                                            "typeName": "RangeAnnotationDouble"
+                                        }
+                                    ],
+                                    "value": 1
+                                },
+                                "y": {
+                                    "annotations": [
+                                        {
+                                            "properties": {
+                                                "max": 1,
+                                                "min": 0
+                                            },
+                                            "typeName": "RangeAnnotationDouble"
+                                        }
+                                    ],
+                                    "value": 1
+                                },
+                                "z": {
+                                    "annotations": [
+                                        {
+                                            "properties": {
+                                                "max": 1,
+                                                "min": 0
+                                            },
+                                            "typeName": "RangeAnnotationDouble"
+                                        }
+                                    ],
+                                    "value": 1
                                 }
                             },
                             "typeName": "Vec3f::EngineTypeAnnotation::LinkStartAnnotation"
@@ -2164,6 +2270,38 @@
                         {
                             "typeName": "String",
                             "value": "diffuse_color"
+                        }
+                    ]
+                }
+            },
+            "typeName": "Link"
+        },
+        {
+            "properties": {
+                "endObject": "948b9d48-97d1-49a9-a6b6-093b9c62826e",
+                "endProp": {
+                    "properties": [
+                        {
+                            "typeName": "String",
+                            "value": "uniforms"
+                        },
+                        {
+                            "typeName": "String",
+                            "value": "u_lightColor"
+                        }
+                    ]
+                },
+                "isValid": true,
+                "startObject": "ba776ca4-6b28-4e7b-b5e5-b9973b4658aa",
+                "startProp": {
+                    "properties": [
+                        {
+                            "typeName": "String",
+                            "value": "luaOutputs"
+                        },
+                        {
+                            "typeName": "String",
+                            "value": "light_color"
                         }
                     ]
                 }

--- a/monkey/scripts/LightControl.lua
+++ b/monkey/scripts/LightControl.lua
@@ -1,21 +1,29 @@
 
--- This script emulates a colorful disco-like light
+-- This script controls the lighting of a Phong-like shading model
 -- The light position is static, but can be switched from three
 -- different positions: left, right, and top (use numbers 0, 1, 2 on light_id to toggle)
--- Additionally, the light color is animated to produce a disco-like effect. This is
--- triggered by the time progression (time_ms input, supposed to be provided with a monotonic
--- timer with milliseconds precision during runtime).
+-- Optionally specify a diffuse_color to override the default (green-ish) color
 
 function interface()
     -- Input: index into an array static light positions
     IN.light_id = INT
-    -- Input: time, if available (steady clock, in milliseconds, starts at 1, use 0 to disable)
-    IN.time_ms = INT
+    -- Input: diffuse color (setting to zero causes the script to use its default value, see init())
+    IN.diffuse_color = VEC3F
+    -- Input: light color (setting to zero causes the script to use its default value, see init())
+    IN.light_color = VEC3F
 
     -- Output: direction of light in that static position
     OUT.light_direction = VEC3F
+    -- Output: light color
+    OUT.light_color = VEC3F
     -- Output: diffuse color for material(s)
     OUT.diffuse_color = VEC3F
+end
+
+function init()
+    -- Declares default colors which are used if no other value was provided in the INputs
+    GLOBAL.default_color = {0.28, 0.82, 0.6}
+    GLOBAL.default_light_color = {1.0, 1.0, 1.0}
 end
 
 function run()
@@ -32,13 +40,17 @@ function run()
 
     OUT.light_direction = lightDirections[lightId]
 
-    if IN.time_ms ~= 0 then
-        OUT.diffuse_color = {
-            math.abs(math.sin(IN.time_ms / 1000.0)),
-            math.abs(math.cos(IN.time_ms / 10000.0)),
-            math.abs(math.sin(IN.time_ms / 10000.0))
-        }
+    -- If a light color value was given (IN.light_color), forward it. Otherwise assign default color
+    if IN.light_color[1] ~= 0 or IN.light_color[2] ~= 0 or IN.light_color[3] ~= 0 then
+        OUT.light_color = IN.light_color
     else
-        OUT.diffuse_color = {0.1, 0.1, 1.0}
+        OUT.light_color = GLOBAL.default_light_color
+    end
+
+    -- If a diffuse color value was given (IN.diffuse_color), forward it. Otherwise assign default color
+    if IN.diffuse_color[1] ~= 0 or IN.diffuse_color[2] ~= 0 or IN.diffuse_color[3] ~= 0 then
+        OUT.diffuse_color = IN.diffuse_color
+    else
+        OUT.diffuse_color = GLOBAL.default_color
     end
 end


### PR DESCRIPTION
The monkey example used to have a 'time_ms' which RaCo considers
deprecated now. Removed it completely and updated the docs to not
mention it. Also added an init() function to demonstrate how
storing global variables works in Lua. Improved the structure of
the Lua-related part of the readme.